### PR TITLE
Fix make pipeconf-install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ curr_dir := $(patsubst %/,%,$(dir $(mkfile_path)))
 p4_src_dir := $(STRATUM_ROOT)/stratum/pipelines/main
 p4_build_dir := src/main/resources
 
-pipeconf_app_name := org.onosproject.stratum-bcm-pipeconf
-pipeconf_oar_file := $(shell ls -1 ${curr_dir}/target/stratum-bcm-pipeconf-*.oar 2> /dev/null)
+pipeconf_app_name := org.stratumproject.bcm-pipeconf
+pipeconf_oar_file := $(shell ls -1 ${curr_dir}/target/bcm-pipeconf-*.oar 2> /dev/null)
 
 curr_dir_sha := $(shell echo -n "$(curr_dir)" | shasum | cut -c1-7)
 app_build_container_name := app-build-${curr_dir_sha}


### PR DESCRIPTION
Hey,

This PR fixes the `make pipeconf-install` target in the project makefile. The artifact id defined in the app pom.xml file is `bcm-pipeconf` and not `stratum-bcm-pipeconf`.

https://github.com/stratum/bcm-pipeconf/blob/master/pom.xml#L19

This is a regression introduced with https://github.com/stratum/bcm-pipeconf/commit/5e152c6ec9a8bf367a9bc4a6785ac01323cd9dc6

@Yi-Tseng

Thanks